### PR TITLE
Modifying the readme so the client SSH config only matches logging in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Type the following command on the **client** (Mac OS X Terminal or Linux) to cop
 
 Add the following to the end of `~/.ssh/config`:
 
-    Host server
+    Match originalhost serverIP user root
         HostName serverIP
         User root
         UserKnownHostsFile ~/.ssh/known_hosts.initramfs

--- a/hooks/crypt_unlock.sh
+++ b/hooks/crypt_unlock.sh
@@ -21,7 +21,10 @@ copy_exec /bin/keyctl
 
 if [ "${DROPBEAR}" != "n" ] && [ -r "/etc/crypttab" ] ; then
     #run unlock on ssh login
-    echo unlock>${DESTDIR}/root/.profile
+    # In some versions of update-initramfs, instead of just a /root dir in the initramfs, it's /root-a12b3 or something like that with a dynamic suffix
+    # So the following line figures out what the actual root directory is
+    ROOTDIR=`find ${DESTDIR} -maxdepth 1 -type d -name root* -print | head -n 1`
+    echo unlock>${ROOTDIR}/.profile
         #write the unlock script
     cat > "${DESTDIR}/bin/unlock" <<EOF
 #!/bin/sh


### PR DESCRIPTION
…to the server as root by its IP (to prevent known host errors when logging into it otherwise)

Also editing the crypt_unlock.sh script so that it finds dynamic root-user directories in initramfs